### PR TITLE
Use constants in events and status, mock HTML Audio load function and remove useless wait for

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/src/hooks/useAudio/useAudio.test.ts
+++ b/src/hooks/useAudio/useAudio.test.ts
@@ -6,8 +6,13 @@ import useAudio from './useAudio';
 import { CreateAudioArgs } from './useAudio.types';
 
 describe('useAudio', () => {
+  beforeAll(() => {
+    window.HTMLMediaElement.prototype.load = jest.fn();
+  });
+
   describe('onCreateAudio', () => {
     test('should create audio element', async () => {
+      let audio: HTMLAudioElement | undefined = undefined;
       const { result } = renderHook(() => useAudio());
 
       const args: CreateAudioArgs = {
@@ -21,25 +26,17 @@ describe('useAudio', () => {
         loop: false,
       };
 
-      const audio:
-        | HTMLAudioElement
-        | undefined = await result.current.onCreateAudio(args);
-
-      await waitFor(() => {
-        // For some reason, when calling toBeInTheDocument() does not work.
-        // When using .toBeInTheDocuments tests pass but ESLint complains about it.
-        // So, there is why the next line is disabled.
-        // Should be fixed in a next version though.
-        // eslint-disable-next-line
-        expect(audio).toBeInTheDocument;
-        expect(audio).toBeInstanceOf(HTMLAudioElement);
-        expect(audio).toHaveProperty('preload', args.preload);
-        expect(audio).toHaveProperty('autoplay', args.autoplay);
-        expect(audio).toHaveProperty('volume', args.volume);
-        expect(audio).toHaveProperty('playbackRate', args.rate);
-        expect(audio).toHaveProperty('muted', args.mute);
-        expect(audio).toHaveProperty('loop', args.loop);
+      await waitFor(async () => {
+        audio = await result.current.onCreateAudio(args);
       });
+
+      expect(audio).toBeInstanceOf(HTMLAudioElement);
+      expect(audio).toHaveProperty('preload', args.preload);
+      expect(audio).toHaveProperty('autoplay', args.autoplay);
+      expect(audio).toHaveProperty('volume', args.volume);
+      expect(audio).toHaveProperty('playbackRate', args.rate);
+      expect(audio).toHaveProperty('muted', args.mute);
+      expect(audio).toHaveProperty('loop', args.loop);
     });
 
     test('should create audio element with preload equal "metadata"', async () => {
@@ -60,17 +57,13 @@ describe('useAudio', () => {
         | HTMLAudioElement
         | undefined = await result.current.onCreateAudio(args);
 
-      await waitFor(() => {
-        // eslint-disable-next-line
-        expect(audio).toBeInTheDocument;
-        expect(audio).toBeInstanceOf(HTMLAudioElement);
-        expect(audio).toHaveProperty('preload', args.preload);
-        expect(audio).toHaveProperty('autoplay', args.autoplay);
-        expect(audio).toHaveProperty('volume', args.volume);
-        expect(audio).toHaveProperty('playbackRate', args.rate);
-        expect(audio).toHaveProperty('muted', args.mute);
-        expect(audio).toHaveProperty('loop', args.loop);
-      });
+      expect(audio).toBeInstanceOf(HTMLAudioElement);
+      expect(audio).toHaveProperty('preload', args.preload);
+      expect(audio).toHaveProperty('autoplay', args.autoplay);
+      expect(audio).toHaveProperty('volume', args.volume);
+      expect(audio).toHaveProperty('playbackRate', args.rate);
+      expect(audio).toHaveProperty('muted', args.mute);
+      expect(audio).toHaveProperty('loop', args.loop);
     });
 
     test('should create audio element with preload equal "none"', async () => {
@@ -91,17 +84,13 @@ describe('useAudio', () => {
         | HTMLAudioElement
         | undefined = await result.current.onCreateAudio(args);
 
-      await waitFor(() => {
-        // eslint-disable-next-line
-        expect(audio).toBeInTheDocument;
-        expect(audio).toBeInstanceOf(HTMLAudioElement);
-        expect(audio).toHaveProperty('preload', args.preload);
-        expect(audio).toHaveProperty('autoplay', args.autoplay);
-        expect(audio).toHaveProperty('volume', args.volume);
-        expect(audio).toHaveProperty('playbackRate', args.rate);
-        expect(audio).toHaveProperty('muted', args.mute);
-        expect(audio).toHaveProperty('loop', args.loop);
-      });
+      expect(audio).toBeInstanceOf(HTMLAudioElement);
+      expect(audio).toHaveProperty('preload', args.preload);
+      expect(audio).toHaveProperty('autoplay', args.autoplay);
+      expect(audio).toHaveProperty('volume', args.volume);
+      expect(audio).toHaveProperty('playbackRate', args.rate);
+      expect(audio).toHaveProperty('muted', args.mute);
+      expect(audio).toHaveProperty('loop', args.loop);
     });
 
     test('should create audio element with autoplay equal "false"', async () => {
@@ -122,17 +111,13 @@ describe('useAudio', () => {
         | HTMLAudioElement
         | undefined = await result.current.onCreateAudio(args);
 
-      await waitFor(() => {
-        // eslint-disable-next-line
-        expect(audio).toBeInTheDocument;
-        expect(audio).toBeInstanceOf(HTMLAudioElement);
-        expect(audio).toHaveProperty('preload', args.preload);
-        expect(audio).toHaveProperty('autoplay', args.autoplay);
-        expect(audio).toHaveProperty('volume', args.volume);
-        expect(audio).toHaveProperty('playbackRate', args.rate);
-        expect(audio).toHaveProperty('muted', args.mute);
-        expect(audio).toHaveProperty('loop', args.loop);
-      });
+      expect(audio).toBeInstanceOf(HTMLAudioElement);
+      expect(audio).toHaveProperty('preload', args.preload);
+      expect(audio).toHaveProperty('autoplay', args.autoplay);
+      expect(audio).toHaveProperty('volume', args.volume);
+      expect(audio).toHaveProperty('playbackRate', args.rate);
+      expect(audio).toHaveProperty('muted', args.mute);
+      expect(audio).toHaveProperty('loop', args.loop);
     });
 
     test('should create audio element with volume equal "0.5"', async () => {
@@ -153,17 +138,13 @@ describe('useAudio', () => {
         | HTMLAudioElement
         | undefined = await result.current.onCreateAudio(args);
 
-      await waitFor(() => {
-        // eslint-disable-next-line
-        expect(audio).toBeInTheDocument;
-        expect(audio).toBeInstanceOf(HTMLAudioElement);
-        expect(audio).toHaveProperty('preload', args.preload);
-        expect(audio).toHaveProperty('autoplay', args.autoplay);
-        expect(audio).toHaveProperty('volume', args.volume);
-        expect(audio).toHaveProperty('playbackRate', args.rate);
-        expect(audio).toHaveProperty('muted', args.mute);
-        expect(audio).toHaveProperty('loop', args.loop);
-      });
+      expect(audio).toBeInstanceOf(HTMLAudioElement);
+      expect(audio).toHaveProperty('preload', args.preload);
+      expect(audio).toHaveProperty('autoplay', args.autoplay);
+      expect(audio).toHaveProperty('volume', args.volume);
+      expect(audio).toHaveProperty('playbackRate', args.rate);
+      expect(audio).toHaveProperty('muted', args.mute);
+      expect(audio).toHaveProperty('loop', args.loop);
     });
 
     test('should create audio element with rate equal "0.5"', async () => {
@@ -184,17 +165,13 @@ describe('useAudio', () => {
         | HTMLAudioElement
         | undefined = await result.current.onCreateAudio(args);
 
-      await waitFor(() => {
-        // eslint-disable-next-line
-        expect(audio).toBeInTheDocument;
-        expect(audio).toBeInstanceOf(HTMLAudioElement);
-        expect(audio).toHaveProperty('preload', args.preload);
-        expect(audio).toHaveProperty('autoplay', args.autoplay);
-        expect(audio).toHaveProperty('volume', args.volume);
-        expect(audio).toHaveProperty('playbackRate', args.rate);
-        expect(audio).toHaveProperty('muted', args.mute);
-        expect(audio).toHaveProperty('loop', args.loop);
-      });
+      expect(audio).toBeInstanceOf(HTMLAudioElement);
+      expect(audio).toHaveProperty('preload', args.preload);
+      expect(audio).toHaveProperty('autoplay', args.autoplay);
+      expect(audio).toHaveProperty('volume', args.volume);
+      expect(audio).toHaveProperty('playbackRate', args.rate);
+      expect(audio).toHaveProperty('muted', args.mute);
+      expect(audio).toHaveProperty('loop', args.loop);
     });
 
     test('should create audio element with muted equal "true"', async () => {
@@ -215,17 +192,13 @@ describe('useAudio', () => {
         | HTMLAudioElement
         | undefined = await result.current.onCreateAudio(args);
 
-      await waitFor(() => {
-        // eslint-disable-next-line
-        expect(audio).toBeInTheDocument;
-        expect(audio).toBeInstanceOf(HTMLAudioElement);
-        expect(audio).toHaveProperty('preload', args.preload);
-        expect(audio).toHaveProperty('autoplay', args.autoplay);
-        expect(audio).toHaveProperty('volume', args.volume);
-        expect(audio).toHaveProperty('playbackRate', args.rate);
-        expect(audio).toHaveProperty('muted', args.mute);
-        expect(audio).toHaveProperty('loop', args.loop);
-      });
+      expect(audio).toBeInstanceOf(HTMLAudioElement);
+      expect(audio).toHaveProperty('preload', args.preload);
+      expect(audio).toHaveProperty('autoplay', args.autoplay);
+      expect(audio).toHaveProperty('volume', args.volume);
+      expect(audio).toHaveProperty('playbackRate', args.rate);
+      expect(audio).toHaveProperty('muted', args.mute);
+      expect(audio).toHaveProperty('loop', args.loop);
     });
 
     test('should create audio element with loop equal "true"', async () => {
@@ -246,17 +219,13 @@ describe('useAudio', () => {
         | HTMLAudioElement
         | undefined = await result.current.onCreateAudio(args);
 
-      await waitFor(() => {
-        // eslint-disable-next-line
-        expect(audio).toBeInTheDocument;
-        expect(audio).toBeInstanceOf(HTMLAudioElement);
-        expect(audio).toHaveProperty('preload', args.preload);
-        expect(audio).toHaveProperty('autoplay', args.autoplay);
-        expect(audio).toHaveProperty('volume', args.volume);
-        expect(audio).toHaveProperty('playbackRate', args.rate);
-        expect(audio).toHaveProperty('muted', args.mute);
-        expect(audio).toHaveProperty('loop', args.loop);
-      });
+      expect(audio).toBeInstanceOf(HTMLAudioElement);
+      expect(audio).toHaveProperty('preload', args.preload);
+      expect(audio).toHaveProperty('autoplay', args.autoplay);
+      expect(audio).toHaveProperty('volume', args.volume);
+      expect(audio).toHaveProperty('playbackRate', args.rate);
+      expect(audio).toHaveProperty('muted', args.mute);
+      expect(audio).toHaveProperty('loop', args.loop);
     });
   });
 
@@ -279,17 +248,13 @@ describe('useAudio', () => {
         | HTMLAudioElement
         | undefined = await result.current.onLoadAudio(undefined, args);
 
-      await waitFor(() => {
-        // eslint-disable-next-line
-        expect(audio).toBeInTheDocument;
-        expect(audio).toBeInstanceOf(HTMLAudioElement);
-        expect(audio).toHaveProperty('preload', args.preload);
-        expect(audio).toHaveProperty('autoplay', args.autoplay);
-        expect(audio).toHaveProperty('volume', args.volume);
-        expect(audio).toHaveProperty('playbackRate', args.rate);
-        expect(audio).toHaveProperty('muted', args.mute);
-        expect(audio).toHaveProperty('loop', args.loop);
-      });
+      expect(audio).toBeInstanceOf(HTMLAudioElement);
+      expect(audio).toHaveProperty('preload', args.preload);
+      expect(audio).toHaveProperty('autoplay', args.autoplay);
+      expect(audio).toHaveProperty('volume', args.volume);
+      expect(audio).toHaveProperty('playbackRate', args.rate);
+      expect(audio).toHaveProperty('muted', args.mute);
+      expect(audio).toHaveProperty('loop', args.loop);
     });
 
     test('should change audio src', async () => {
@@ -322,8 +287,6 @@ describe('useAudio', () => {
           firstArgs
         );
 
-        // eslint-disable-next-line
-        expect(audio).toBeInTheDocument;
         expect(audio).toBeInstanceOf(HTMLAudioElement);
         expect(audio).toHaveProperty('preload', firstArgs.preload);
         expect(audio).toHaveProperty('autoplay', firstArgs.autoplay);
@@ -334,8 +297,6 @@ describe('useAudio', () => {
 
         result.current.onLoadAudio(audio, secondArgs);
 
-        // eslint-disable-next-line
-        expect(audio).toBeInTheDocument;
         expect(audio).toBeInstanceOf(HTMLAudioElement);
         expect(audio).toHaveProperty('preload', secondArgs.preload);
         expect(audio).toHaveProperty('autoplay', secondArgs.autoplay);
@@ -362,26 +323,21 @@ describe('useAudio', () => {
         loop: true,
       };
 
-      const audio: HTMLAudioElement = await result.current.onCreateAudio(args);
+      let audio:
+        | HTMLAudioElement
+        | undefined = await result.current.onCreateAudio(args);
 
-      await waitFor(() => {
-        // eslint-disable-next-line
-        expect(audio).toBeInTheDocument;
-        expect(audio).toBeInstanceOf(HTMLAudioElement);
-        expect(audio).toHaveProperty('preload', args.preload);
-        expect(audio).toHaveProperty('autoplay', args.autoplay);
-        expect(audio).toHaveProperty('volume', args.volume);
-        expect(audio).toHaveProperty('playbackRate', args.rate);
-        expect(audio).toHaveProperty('muted', args.mute);
-        expect(audio).toHaveProperty('loop', args.loop);
-      });
+      expect(audio).toBeInstanceOf(HTMLAudioElement);
+      expect(audio).toHaveProperty('preload', args.preload);
+      expect(audio).toHaveProperty('autoplay', args.autoplay);
+      expect(audio).toHaveProperty('volume', args.volume);
+      expect(audio).toHaveProperty('playbackRate', args.rate);
+      expect(audio).toHaveProperty('muted', args.mute);
+      expect(audio).toHaveProperty('loop', args.loop);
 
-      await result.current.onDestroyAudio(audio);
+      audio = await result.current.onDestroyAudio(audio);
 
-      await waitFor(() => {
-        // eslint-disable-next-line
-        expect(audio).not.toBeInTheDocument;
-      });
+      expect(audio).toBeUndefined();
     });
 
     test('should not destroy audio and return undefined when there is no audio', async () => {
@@ -389,7 +345,7 @@ describe('useAudio', () => {
 
       const destroyFn = await result.current.onDestroyAudio(undefined);
 
-      expect(destroyFn).toBe(undefined);
+      expect(destroyFn).toBeUndefined();
     });
   });
 });

--- a/src/hooks/useAudio/useAudio.ts
+++ b/src/hooks/useAudio/useAudio.ts
@@ -9,6 +9,8 @@ import {
   MachineEvent,
 } from '../../types';
 
+import { EVENTS, STATUS } from '../../utils/constants';
+
 const useAudio: UseAudio = () => {
   const service = useInterpret<MachineContext, MachineEvent>(RooverMachine, {
     devTools: process.env.NODE_ENV === 'development',
@@ -47,7 +49,7 @@ const useAudio: UseAudio = () => {
 
     // When the audio has started to load, it will trigger a 'LOAD' event.
     audioElement.addEventListener('loadstart', () => {
-      service.send('LOAD', {
+      service.send(STATUS.LOAD, {
         volume: volume,
         rate: rate,
         mute: mute,
@@ -56,37 +58,37 @@ const useAudio: UseAudio = () => {
     });
     // When the audio has loaded successfully, it will triger a 'READY' event and change values in the context.
     audioElement.addEventListener('loadeddata', () => {
-      service.send('READY', { duration: audioElement.duration });
+      service.send(STATUS.READY, { duration: audioElement.duration });
     });
     // When the audio has a loading error, it will trigger a 'ERROR' event.
     audioElement.addEventListener('error', () => {
-      service.send('ERROR', {
+      service.send(STATUS.ERROR, {
         error: `Error while loading: ${src}`,
       });
     });
     // When the audio plays, it will trigger a 'PLAY' event.
     audioElement.addEventListener('play', () => {
-      service.send('PLAY');
+      service.send(EVENTS.PLAY);
     });
     // When the audio has paused, it will trigger a 'PAUSE' event.
     audioElement.addEventListener('pause', () => {
-      service.send('PAUSE');
+      service.send(EVENTS.PAUSE);
     });
     // When the volume has changed, will trigger a 'VOLUME' event and set the new value in the context.
     audioElement.addEventListener('volumechange', () => {
-      service.send('VOLUME', {
+      service.send(EVENTS.VOLUME, {
         volume: audioElement.volume,
       });
     });
     // When the rate has changed, it will trigger a 'RATE' event and set the new value in the context.
     audioElement.addEventListener('ratechange', () => {
-      service.send('RATE', {
+      service.send(EVENTS.RATE, {
         rate: audioElement.playbackRate,
       });
     });
     // When the audio has ended, it will trigger a 'END' event.
     audioElement.addEventListener('ended', () => {
-      service.send('END');
+      service.send(EVENTS.END);
     });
 
     return audioElement;
@@ -132,13 +134,14 @@ const useAudio: UseAudio = () => {
    * @param audio - The audio element to be checked.
    * @returns undefined
    */
-  const onDestroyAudio = (audio: HTMLAudioElement | undefined): void => {
+  const onDestroyAudio = (audio: HTMLAudioElement | undefined): undefined => {
     if (!audio) {
       return undefined;
     } else {
       audio.currentTime = 0;
       audio.removeAttribute('src');
       audio = undefined;
+      return audio;
     }
   };
 

--- a/src/hooks/useAudio/useAudio.types.ts
+++ b/src/hooks/useAudio/useAudio.types.ts
@@ -9,7 +9,7 @@ export type UseAudio = () => {
     audio: HTMLAudioElement | undefined,
     args: CreateAudioArgs
   ) => HTMLAudioElement;
-  onDestroyAudio: (audio: HTMLAudioElement | undefined) => void;
+  onDestroyAudio: (audio: HTMLAudioElement | undefined) => undefined;
 };
 
 export interface CreateAudioArgs {

--- a/src/hooks/useRoover/useRoover.ts
+++ b/src/hooks/useRoover/useRoover.ts
@@ -6,6 +6,8 @@ import useAudio from '../useAudio/useAudio';
 
 import { Args, ReturnArgs } from './useRoover.types';
 
+import { EVENTS } from '../../utils/constants';
+
 /**
  * The useRoover hook.
  * @param {string} src - The src of the audio to be loaded.
@@ -140,11 +142,11 @@ const useRoover = ({
     } else {
       if (ready || paused) {
         audio.play();
-        service.send('PLAY');
+        service.send(EVENTS.PLAY);
       }
       if (playing) {
         audio.pause();
-        service.send('PAUSE');
+        service.send(EVENTS.PAUSE);
       }
     }
   };
@@ -169,7 +171,7 @@ const useRoover = ({
     } else {
       if (ready || paused) {
         audio.play();
-        service.send('PLAY');
+        service.send(EVENTS.PLAY);
       }
     }
   };
@@ -180,7 +182,7 @@ const useRoover = ({
    */
   const onPause = (): void => {
     if (!audio) return;
-    service.send('PAUSE');
+    service.send(EVENTS.PAUSE);
     audio.pause();
   };
 
@@ -190,7 +192,7 @@ const useRoover = ({
    */
   const onMute = (): void => {
     if (!audio) return;
-    service.send('MUTE');
+    service.send(EVENTS.MUTE);
     audio.muted = !playerContextMute;
   };
 
@@ -200,7 +202,7 @@ const useRoover = ({
    */
   const onLoop = (): void => {
     if (!audio) return;
-    service.send('LOOP');
+    service.send(EVENTS.LOOP);
     audio.loop = !playerContextLoop;
   };
 
@@ -211,7 +213,7 @@ const useRoover = ({
    */
   const onVolume = (value: number): void => {
     if (!audio) return;
-    service.send({ type: 'VOLUME', volume: value });
+    service.send({ type: EVENTS.VOLUME, volume: value });
     audio.volume = value;
   };
 
@@ -223,7 +225,7 @@ const useRoover = ({
   const onRate = (value: string): void => {
     if (!audio) return;
     const rate: number = parseFloat(value);
-    service.send({ type: 'RATE', rate });
+    service.send({ type: EVENTS.RATE, rate });
     audio.playbackRate = rate;
   };
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,0 +1,15 @@
+export const EVENTS = {
+  PLAY: 'PLAY',
+  PAUSE: 'PAUSE',
+  MUTE: 'MUTE',
+  VOLUME: 'VOLUME',
+  RATE: 'RATE',
+  LOOP: 'LOOP',
+  END: 'END',
+} as const;
+
+export const STATUS = {
+  LOAD: 'LOAD',
+  READY: 'READY',
+  ERROR: 'ERROR',
+} as const;


### PR DESCRIPTION
I create a mock to make work load function in project and solve tests

https://github.com/jsdom/jsdom/issues/2155#issuecomment-366703395


```js
// This doest not work because you instantiate a Audio class and its not present in the dom (because its not an html element) , all that is rendered is an empty body
expect(audio).toBeInTheDocument()
```

And finally, you do not need waitFor to check all the properties, because you wait create a audio instance and this is enough